### PR TITLE
Update amazon-workspaces-osx-client.md

### DIFF
--- a/doc_source/amazon-workspaces-osx-client.md
+++ b/doc_source/amazon-workspaces-osx-client.md
@@ -118,7 +118,7 @@ You can switch to full screen mode by choosing **View**, **Enter Full Screen** \
 
 While in full screen mode, you can switch back to window mode by moving the pointer to the top of the screen\. The client application menu is displayed, and you can choose **View**, **Leave Full Screen** \(3\.0\+ clients\) or **View**, **Exit Fullscreen** \(1\.0\+ and 2\.0\+ clients\) in the client application menu\.
 
-You can also toggle full screen mode by pressing Control\+Option\+Return\.
+You can also toggle full screen mode by pressing Command\+Option\+Return\.
 
 ## Client language<a name="osx_client_lang"></a>
 
@@ -202,7 +202,7 @@ The WorkSpaces macOS client supports the following command shortcuts:
 
 | If you're using\.\.\. | Use these shortcuts | 
 | --- | --- | 
-|  3\.0\+ client  |  Command\+Q—Quit Amazon WorkSpaces Control\+Option\+Return—Toggle full screen display Control\+Option\+F12—Disconnect session  | 
+|  3\.0\+ client  |  Command\+Q—Quit Amazon WorkSpaces Command\+Option\+Return—Toggle full screen display Command\+Option\+F12—Disconnect session  | 
 |  1\.0\+ or 2\.0\+ client  |  Control\+Option\+Return—Toggle full screen display Control\+Option\+F12—Disconnect session  | 
 
 ## Remap the Windows logo key or the Command key<a name="osx_remap_command_key"></a>


### PR DESCRIPTION
Updated keyboard shortcuts to use Command+Option+Return instead of Control+Option+Return.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
